### PR TITLE
Fix logical OR causing syntax error on chromium

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -211,7 +211,7 @@ function copyToClipboard(text, notification) {
 
     chrome.notifications.create('get-rss-feed-url-copy', {
         type: "basic",
-        title: notification.title ?? "Get RSS Feeds URLs",
+        title: notification.title || "Get RSS Feeds URLs",
         message: notification.message,
         iconUrl: "img/notif_"+notification.type+".png"
     });


### PR DESCRIPTION
Fixes "Uncaught SyntaxError: Unexpected token ? (popup:214)". Tested on Ungoogled Chromium