### PR TITLE
48 repeated rss detection requests causing customer ip blocks

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -7,11 +7,11 @@ const tabUpdateTimeouts = new Map();
 // Debounce delay in milliseconds (wait for navigation to stabilize)
 const DEBOUNCE_DELAY = 1000;
 
-// Cache expiration time for positive results (feeds found) - 1 hour
-const CACHE_EXPIRATION = 60 * 60 * 1000;
+// Cache expiration time for positive results (feeds found) - 24 hours
+const CACHE_EXPIRATION = 24 * 60 * 60 * 1000;
 
-// Cache expiration time for negative results (no feeds found) - 24 hours
-const CACHE_EXPIRATION_NEGATIVE = 24 * 60 * 60 * 1000;
+// Cache expiration time for negative results (no feeds found) - 7 days
+const CACHE_EXPIRATION_NEGATIVE = 7 * 24 * 60 * 60 * 1000;
 
 // Cache key prefix
 const CACHE_PREFIX = 'getrss_cache_';

--- a/js/background.js
+++ b/js/background.js
@@ -7,8 +7,11 @@ const tabUpdateTimeouts = new Map();
 // Debounce delay in milliseconds (wait for navigation to stabilize)
 const DEBOUNCE_DELAY = 1000;
 
-// Cache expiration time in milliseconds (1 hour)
+// Cache expiration time for positive results (feeds found) - 1 hour
 const CACHE_EXPIRATION = 60 * 60 * 1000;
+
+// Cache expiration time for negative results (no feeds found) - 24 hours
+const CACHE_EXPIRATION_NEGATIVE = 24 * 60 * 60 * 1000;
 
 // Cache key prefix
 const CACHE_PREFIX = 'getrss_cache_';
@@ -72,12 +75,13 @@ async function cacheFeedCount(url, feedCount, source = "html") {
 
     try {
         const urlObj = new URL(url);
+        const expiration = feedCount === 0 ? CACHE_EXPIRATION_NEGATIVE : CACHE_EXPIRATION;
         const cacheData = {
             feedCount: feedCount,
             pathname: urlObj.pathname,
             source: source,
             timestamp: Date.now(),
-            expiresAt: Date.now() + CACHE_EXPIRATION
+            expiresAt: Date.now() + expiration
         };
 
         await chrome.storage.local.set({ [cacheKey]: cacheData });

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Get RSS Feed URL",
     "description": "Retreive RSS feeds URLs from Website",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "author": "@shevabam",
     "homepage_url": "https://github.com/shevabam/get-rss-feed-url-extension",
     "permissions": [


### PR DESCRIPTION
Extend cache TTL to 7 days for sites with no RSS feeds
Cache for sites with RSS feeds is now 1 day