### PR TITLE
Option to ignore site

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -1,0 +1,362 @@
+/* === Root Variables === */
+:root {
+    --primary-color: #ff9c00;
+    --primary-hover: #e68a00;
+    --primary-light: #fff3e0;
+    --success-color: #4caf50;
+    --danger-color: #dc3545;
+    --background: #ffffff;
+    --surface: #f8f9fa;
+    --text-primary: #212529;
+    --text-secondary: #6c757d;
+    --text-muted: #adb5bd;
+    --border-color: #e9ecef;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+    --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.07);
+    --radius-sm: 6px;
+    --radius-md: 8px;
+    --radius-lg: 12px;
+}
+
+/* === Dark Theme === */
+body.dark-theme {
+    --background: #1a1a1a;
+    --surface: #2d2d2d;
+    --text-primary: #e8e8e8;
+    --text-secondary: #b0b0b0;
+    --text-muted: #808080;
+    --border-color: #404040;
+    --primary-light: #3d2e00;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+    --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.4);
+}
+
+/* === Base === */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-size: 14px;
+    font-family: 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    background: var(--background);
+    color: var(--text-primary);
+    line-height: 1.5;
+    min-height: 100vh;
+}
+
+/* === Header === */
+header {
+    background: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-hover) 100%);
+    padding: 16px 24px;
+    box-shadow: var(--shadow-md);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.header-content {
+    max-width: 640px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    position: relative;
+}
+
+header h1 {
+    font-size: 18px;
+    font-weight: 600;
+    color: white;
+    letter-spacing: 0.3px;
+}
+
+.rss-icon {
+    flex-shrink: 0;
+}
+
+/* === Theme Toggle === */
+.theme-toggle {
+    position: absolute;
+    right: 0;
+    background: rgba(255, 255, 255, 0.2);
+    border: none;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s;
+    color: white;
+}
+
+.theme-toggle:hover {
+    background: rgba(255, 255, 255, 0.3);
+    transform: scale(1.05);
+}
+
+.theme-toggle:active {
+    transform: scale(0.95);
+}
+
+.theme-toggle .sun-icon,
+.theme-toggle .moon-icon {
+    position: absolute;
+    transition: opacity 0.2s, transform 0.2s;
+}
+
+.theme-toggle .sun-icon {
+    opacity: 1;
+    transform: rotate(0deg);
+}
+
+.theme-toggle .moon-icon {
+    opacity: 0;
+    transform: rotate(180deg);
+}
+
+body.dark-theme .theme-toggle .sun-icon {
+    opacity: 0;
+    transform: rotate(180deg);
+}
+
+body.dark-theme .theme-toggle .moon-icon {
+    opacity: 1;
+    transform: rotate(0deg);
+}
+
+/* === Main === */
+main {
+    max-width: 640px;
+    margin: 32px auto;
+    padding: 0 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* === Sections === */
+.options-section {
+    background: var(--surface);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    padding: 20px;
+    box-shadow: var(--shadow-sm);
+}
+
+.section-title {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    color: var(--text-secondary);
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+}
+
+.option-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.option-info {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.option-label {
+    font-weight: 500;
+    font-size: 14px;
+    color: var(--text-primary);
+}
+
+.option-desc {
+    font-size: 12px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+}
+
+/* === Toggle Switch === */
+.toggle-switch {
+    flex-shrink: 0;
+    position: relative;
+    width: 44px;
+    height: 24px;
+    cursor: pointer;
+    display: inline-block;
+}
+
+.toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    position: absolute;
+}
+
+.toggle-slider {
+    position: absolute;
+    inset: 0;
+    background: var(--border-color);
+    border-radius: 24px;
+    transition: background 0.2s;
+}
+
+.toggle-slider::before {
+    content: '';
+    position: absolute;
+    width: 18px;
+    height: 18px;
+    left: 3px;
+    top: 3px;
+    background: white;
+    border-radius: 50%;
+    transition: transform 0.2s;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.toggle-switch input:checked + .toggle-slider {
+    background: var(--primary-color);
+}
+
+.toggle-switch input:checked + .toggle-slider::before {
+    transform: translateX(20px);
+}
+
+/* === Action Buttons === */
+.action-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: transparent;
+    color: var(--primary-color);
+    border: 1px solid var(--primary-color);
+    padding: 7px 14px;
+    border-radius: var(--radius-sm);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.action-btn:hover {
+    background: var(--primary-color);
+    color: white;
+}
+
+.action-btn:active {
+    transform: scale(0.97);
+}
+
+.action-btn.success {
+    background: var(--success-color);
+    border-color: var(--success-color);
+    color: white;
+}
+
+.action-btn.danger {
+    color: var(--danger-color);
+    border-color: var(--danger-color);
+}
+
+.action-btn.danger:hover {
+    background: var(--danger-color);
+    color: white;
+}
+
+/* === Ignored Sites === */
+.empty-list-text {
+    color: var(--text-muted);
+    font-size: 13px;
+    font-style: italic;
+}
+
+.clear-all-row {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 12px;
+}
+
+.sites-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.site-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 14px;
+    background: var(--background);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    transition: border-color 0.2s;
+}
+
+.site-item:hover {
+    border-color: var(--primary-color);
+}
+
+.site-name {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.remove-btn {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 4px 6px;
+    display: flex;
+    align-items: center;
+    border-radius: var(--radius-sm);
+    transition: all 0.2s;
+}
+
+.remove-btn:hover {
+    color: var(--danger-color);
+    background: rgba(220, 53, 69, 0.1);
+}
+
+/* === Footer === */
+footer {
+    background: var(--surface);
+    text-align: center;
+    font-size: 12px;
+    color: var(--text-muted);
+    padding: 16px 24px;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px 8px;
+    margin-top: 12px;
+}
+
+footer a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    transition: color 0.2s;
+}
+
+footer a:hover {
+    color: var(--primary-color);
+}
+
+.separator {
+    color: var(--text-muted);
+}

--- a/css/popup.css
+++ b/css/popup.css
@@ -384,6 +384,82 @@ body.dark-theme .theme-toggle .moon-icon {
     color: var(--text-muted);
 }
 
+/* Ignore Site Toggle Button */
+.ignore-toggle {
+    position: absolute;
+    left: 0;
+    background: rgba(255, 255, 255, 0.2);
+    border: none;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s;
+    color: white;
+}
+.ignore-toggle:hover {
+    background: rgba(255, 255, 255, 0.3);
+    transform: scale(1.05);
+}
+.ignore-toggle:active {
+    transform: scale(0.95);
+}
+.ignore-toggle.is-ignored {
+    background: rgba(220, 53, 69, 0.75);
+}
+.ignore-toggle.is-ignored:hover {
+    background: rgba(220, 53, 69, 0.95);
+}
+
+/* === Ignored State === */
+.ignored-state {
+    text-align: center;
+    padding: 32px 20px 24px;
+}
+.ignored-state-icon {
+    width: 56px;
+    height: 56px;
+    margin: 0 auto 14px;
+    color: var(--text-muted);
+    opacity: 0.45;
+}
+.ignored-state-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 8px;
+}
+.ignored-state-text {
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin-bottom: 18px;
+}
+.unignore-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: transparent;
+    color: var(--primary-color);
+    border: 1px solid var(--primary-color);
+    padding: 6px 16px;
+    border-radius: var(--radius-sm);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+.unignore-btn:hover {
+    background: var(--primary-color);
+    color: white;
+}
+.unignore-btn:active {
+    transform: scale(0.97);
+}
+
 /* === Hidden Response Container === */
 .rss-feed-url #rss-feed-url_response {
     display: none;

--- a/css/popup.css
+++ b/css/popup.css
@@ -58,9 +58,14 @@ body.rss-feed-url {
 .header-content {
     display: flex;
     align-items: center;
-    justify-content: center;
     gap: 10px;
-    position: relative;
+}
+
+.header-actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 6px;
 }
 
 .rss-icon {
@@ -77,10 +82,32 @@ body.rss-feed-url {
     margin: 0;
 }
 
+/* Settings Toggle Button */
+.settings-toggle {
+    background: rgba(255, 255, 255, 0.2);
+    border: none;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s;
+    color: white;
+}
+
+.settings-toggle:hover {
+    background: rgba(255, 255, 255, 0.3);
+    transform: scale(1.05);
+}
+
+.settings-toggle:active {
+    transform: scale(0.95);
+}
+
 /* Theme Toggle Button */
 .theme-toggle {
-    position: absolute;
-    right: 0;
     background: rgba(255, 255, 255, 0.2);
     border: none;
     width: 32px;
@@ -386,8 +413,6 @@ body.dark-theme .theme-toggle .moon-icon {
 
 /* Ignore Site Toggle Button */
 .ignore-toggle {
-    position: absolute;
-    left: 0;
     background: rgba(255, 255, 255, 0.2);
     border: none;
     width: 32px;

--- a/js/background.js
+++ b/js/background.js
@@ -134,11 +134,14 @@ async function updateBadge(tabId, url) {
         }
     } catch(e) {}
 
+    // Check if badge display is enabled
+    const { showBadge = true } = await chrome.storage.sync.get(['showBadge']);
+
     // Check cache first
     const cachedCount = await getCachedFeedCount(url);
     if (cachedCount !== null) {
         // Use cached result
-        if (cachedCount === 0) {
+        if (cachedCount === 0 || !showBadge) {
             chrome.action.setBadgeText({ text: "", tabId: tabId });
         } else {
             chrome.action.setBadgeText({ text: cachedCount.toString(), tabId: tabId });
@@ -177,7 +180,7 @@ async function updateBadge(tabId, url) {
     await cacheFeedCount(url, feedCount, source);
 
     // Update badge
-    if (feedCount === 0) {
+    if (feedCount === 0 || !showBadge) {
         chrome.action.setBadgeText({ text: "", tabId: tabId });
     } else {
         chrome.action.setBadgeText({ text: feedCount.toString(), tabId: tabId });
@@ -230,12 +233,15 @@ chrome.tabs.onRemoved.addListener(function(tabId) {
 // Listen for messages from popup to update badge
 chrome.runtime.onMessage.addListener(function(request) {
     if (request.action === "updateBadge" && request.tabId) {
-        if (request.feedCount === 0) {
-            chrome.action.setBadgeText({ text: "", tabId: request.tabId });
-        } else {
-            chrome.action.setBadgeText({ text: request.feedCount.toString(), tabId: request.tabId });
-            chrome.action.setBadgeBackgroundColor({ color: "#82b2faff", tabId: request.tabId });
-        }
+        chrome.storage.sync.get(['showBadge'], function(result) {
+            const showBadge = result.showBadge !== false;
+            if (request.feedCount === 0 || !showBadge) {
+                chrome.action.setBadgeText({ text: "", tabId: request.tabId });
+            } else {
+                chrome.action.setBadgeText({ text: request.feedCount.toString(), tabId: request.tabId });
+                chrome.action.setBadgeBackgroundColor({ color: "#82b2faff", tabId: request.tabId });
+            }
+        });
     }
 });
 

--- a/js/background.js
+++ b/js/background.js
@@ -125,6 +125,15 @@ async function updateBadge(tabId, url) {
         return;
     }
 
+    // Skip sites the user has chosen to ignore
+    try {
+        const { ignoredSites = [] } = await chrome.storage.sync.get(['ignoredSites']);
+        if (ignoredSites.includes(new URL(url).hostname)) {
+            chrome.action.setBadgeText({ text: "", tabId: tabId });
+            return;
+        }
+    } catch(e) {}
+
     // Check cache first
     const cachedCount = await getCachedFeedCount(url);
     if (cachedCount !== null) {

--- a/js/options.js
+++ b/js/options.js
@@ -1,0 +1,126 @@
+const CACHE_PREFIX = 'getrss_cache_';
+
+// Theme management (same pattern as popup.js)
+function initTheme() {
+    chrome.storage.sync.get(['theme'], function(result) {
+        if (result.theme === 'dark') {
+            document.body.classList.add('dark-theme');
+        }
+    });
+
+    document.getElementById('theme-toggle').addEventListener('click', function() {
+        const isDark = document.body.classList.toggle('dark-theme');
+        chrome.storage.sync.set({ theme: isDark ? 'dark' : 'light' });
+    });
+}
+
+initTheme();
+
+document.addEventListener('DOMContentLoaded', function() {
+    document.getElementById('review-link').href = `https://chromewebstore.google.com/detail/${chrome.runtime.id}/reviews`;
+    initBadgeToggle();
+    initClearCache();
+    renderIgnoredSites();
+});
+
+function initBadgeToggle() {
+    const checkbox = document.getElementById('show-badge');
+    chrome.storage.sync.get(['showBadge'], function(result) {
+        checkbox.checked = result.showBadge !== false;
+    });
+    checkbox.addEventListener('change', function() {
+        chrome.storage.sync.set({ showBadge: this.checked });
+    });
+}
+
+function initClearCache() {
+    const btn = document.getElementById('clear-cache-btn');
+    const btnText = btn.querySelector('.btn-text');
+
+    btn.addEventListener('click', async function() {
+        const allData = await chrome.storage.local.get(null);
+        const keysToRemove = Object.keys(allData).filter(k => k.startsWith(CACHE_PREFIX));
+        if (keysToRemove.length > 0) {
+            await chrome.storage.local.remove(keysToRemove);
+        }
+
+        const originalText = btnText.textContent;
+        btnText.textContent = 'Cleared!';
+        btn.classList.add('success');
+
+        setTimeout(() => {
+            btnText.textContent = originalText;
+            btn.classList.remove('success');
+        }, 2000);
+    });
+}
+
+function renderIgnoredSites() {
+    const container = document.getElementById('ignored-sites-container');
+
+    chrome.storage.sync.get(['ignoredSites'], function(result) {
+        const sites = result.ignoredSites || [];
+        container.innerHTML = '';
+
+        if (sites.length === 0) {
+            const p = document.createElement('p');
+            p.className = 'empty-list-text';
+            p.textContent = 'No ignored sites.';
+            container.appendChild(p);
+            return;
+        }
+
+        // "Remove All" button
+        const clearAllRow = document.createElement('div');
+        clearAllRow.className = 'clear-all-row';
+
+        const clearAllBtn = document.createElement('button');
+        clearAllBtn.className = 'action-btn danger';
+        clearAllBtn.textContent = 'Remove All';
+        clearAllBtn.addEventListener('click', function() {
+            chrome.storage.sync.set({ ignoredSites: [] }, renderIgnoredSites);
+        });
+
+        clearAllRow.appendChild(clearAllBtn);
+        container.appendChild(clearAllRow);
+
+        // Sites list
+        const ul = document.createElement('ul');
+        ul.className = 'sites-list';
+
+        for (const site of sites) {
+            const li = document.createElement('li');
+            li.className = 'site-item';
+
+            const span = document.createElement('span');
+            span.className = 'site-name';
+            span.textContent = site;
+
+            const removeBtn = document.createElement('button');
+            removeBtn.className = 'remove-btn';
+            removeBtn.title = 'Remove from ignored list';
+            removeBtn.setAttribute('aria-label', `Remove ${site} from ignored list`);
+
+            const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+            svg.setAttribute('width', '14');
+            svg.setAttribute('height', '14');
+            svg.setAttribute('viewBox', '0 0 24 24');
+            svg.setAttribute('fill', 'none');
+            svg.innerHTML = '<path d="M18 6L6 18M6 6L18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>';
+            removeBtn.appendChild(svg);
+
+            removeBtn.addEventListener('click', function() {
+                chrome.storage.sync.get(['ignoredSites'], function(r) {
+                    const updated = (r.ignoredSites || []).filter(s => s !== site);
+                    chrome.storage.sync.set({ ignoredSites: updated }, renderIgnoredSites);
+                });
+            });
+
+            li.appendChild(span);
+            li.appendChild(removeBtn);
+            ul.appendChild(li);
+        }
+
+        container.appendChild(ul);
+    });
+}

--- a/js/popup.js
+++ b/js/popup.js
@@ -26,6 +26,9 @@ initTheme();
 
 document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('review-link').href = `https://chromewebstore.google.com/detail/${chrome.runtime.id}/reviews`;
+    document.getElementById('options-btn').addEventListener('click', function() {
+        chrome.runtime.openOptionsPage();
+    });
 
     chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
         const tab = tabs[0];
@@ -300,7 +303,7 @@ function createFeedCard(feed, tabTitle) {
     const urlSpan = document.createElement('span');
     urlSpan.className = 'feed-url';
     urlSpan.title = feed.url;
-    urlSpan.textContent = truncate(feed.url, 55);
+    urlSpan.textContent = truncate(feed.url, 60);
 
     const actions = document.createElement('div');
     actions.className = 'feed-actions';

--- a/js/popup.js
+++ b/js/popup.js
@@ -31,92 +31,147 @@ document.addEventListener('DOMContentLoaded', function() {
         const tab = tabs[0];
         const url = tab.url;
 
-        // Warn the user if the search is taking longer than expected
-        const slowTimer = setTimeout(() => {
-            const loaderText = document.querySelector('.loader-text');
-            if (loaderText) loaderText.textContent = 'Still searching, this may take a moment…';
-        }, 3000);
+        // Determine hostname for the ignore feature (http/https only)
+        let hostname = null;
+        try {
+            const urlObj = new URL(url);
+            if (urlObj.protocol === 'http:' || urlObj.protocol === 'https:') {
+                hostname = urlObj.hostname;
+            }
+        } catch(e) {}
 
-        // Hard timeout: stop waiting after 10s
-        const hardTimer = setTimeout(() => {
-            render('The search timed out. The page may be slow or blocking requests.');
-        }, 10000);
+        // Hide ignore button for non-http pages (chrome://, etc.)
+        const ignoreBtn = document.getElementById('ignore-site');
+        if (!hostname) {
+            ignoreBtn.style.display = 'none';
+        }
 
-        getFeedsURLs(url, function(feeds){
-            clearTimeout(slowTimer);
-            clearTimeout(hardTimer);
+        // Check ignored sites list, then proceed
+        chrome.storage.sync.get(['ignoredSites'], function(result) {
+            const ignoredSites = result.ignoredSites || [];
+            const isIgnored = hostname !== null && ignoredSites.includes(hostname);
 
-            // Send feed count to background to update badge
-            chrome.runtime.sendMessage({
-                action: "updateBadge",
-                tabId: tab.id,
-                feedCount: feeds.length
-            });
-
-            if (feeds.length > 0) {
-                const feedsList = document.createElement('div');
-                feedsList.id = 'feeds-list';
-
-                for (let i = 0; i < feeds.length; i++) {
-                    feedsList.appendChild(createFeedCard(feeds[i], tab.title));
-                }
-
-                const feedsEl = document.getElementById('feeds');
-                feedsEl.innerHTML = '';
-                feedsEl.appendChild(feedsList);
-                feedsEl.appendChild(createCopyAllContainer());
-
-                // Copy to clipboard feed URL
-                const copyButtons = document.getElementsByClassName('copyLink');
-
-                for (let i = 0; i < copyButtons.length; i++) {
-                    copyButtons[i].addEventListener("click", function(e) {
-                        e.preventDefault();
-                        const button = this;
-                        const url = button.getAttribute('data-url');
-                        const btnText = button.querySelector('.btn-text');
-
-                        // Visual feedback
-                        button.classList.add('copied');
-                        const originalText = btnText.textContent;
-                        btnText.textContent = 'Copied!';
-
-                        setTimeout(() => {
-                            button.classList.remove('copied');
-                            btnText.textContent = originalText;
-                        }, 2000);
-
-                        copyToClipboard(url);
-                    });
-                }
-
-                // Copy to clipboard all feeds URLs
-                const copyButtonAll = document.getElementById('copyAllLinks');
-
-                copyButtonAll.addEventListener("click", function(e) {
-                    e.preventDefault();
-                    const button = this;
-                    const links = document.getElementById('feeds-list').querySelectorAll('.feed-title.link');
-                    const text = Array.from(links).map(a => a.getAttribute('href')).join('\n');
-
-                    // Visual feedback
-                    button.classList.add('copied');
-                    const btnText = button.querySelector('.btn-text');
-                    const originalText = btnText.textContent;
-                    btnText.textContent = 'Copied!';
-
-                    setTimeout(() => {
-                        button.classList.remove('copied');
-                        btnText.textContent = originalText;
-                    }, 2000);
-
-                    copyToClipboard(text);
-                });
-
-            } else {
-                renderEmptyState();
+            if (isIgnored) {
+                ignoreBtn.classList.add('is-ignored');
+                ignoreBtn.title = 'Enable RSS for this site';
+                renderIgnoredState(hostname);
             }
 
+            // Setup ignore button click handler
+            if (hostname) {
+                ignoreBtn.addEventListener('click', function() {
+                    chrome.storage.sync.get(['ignoredSites'], function(result) {
+                        let sites = result.ignoredSites || [];
+                        const idx = sites.indexOf(hostname);
+
+                        if (idx === -1) {
+                            // Add to ignored list
+                            sites.push(hostname);
+                            chrome.storage.sync.set({ ignoredSites: sites }, function() {
+                                chrome.runtime.sendMessage({ action: "updateBadge", tabId: tab.id, feedCount: 0 });
+                                ignoreBtn.classList.add('is-ignored');
+                                ignoreBtn.title = 'Enable RSS for this site';
+                                renderIgnoredState(hostname);
+                            });
+                        } else {
+                            // Remove from ignored list
+                            sites.splice(idx, 1);
+                            chrome.storage.sync.set({ ignoredSites: sites }, function() {
+                                location.reload();
+                            });
+                        }
+                    });
+                });
+            }
+
+            if (!isIgnored) {
+                // Warn the user if the search is taking longer than expected
+                const slowTimer = setTimeout(() => {
+                    const loaderText = document.querySelector('.loader-text');
+                    if (loaderText) loaderText.textContent = 'Still searching, this may take a moment…';
+                }, 3000);
+
+                // Hard timeout: stop waiting after 10s
+                const hardTimer = setTimeout(() => {
+                    render('The search timed out. The page may be slow or blocking requests.');
+                }, 10000);
+
+                getFeedsURLs(url, function(feeds){
+                    clearTimeout(slowTimer);
+                    clearTimeout(hardTimer);
+
+                    // Send feed count to background to update badge
+                    chrome.runtime.sendMessage({
+                        action: "updateBadge",
+                        tabId: tab.id,
+                        feedCount: feeds.length
+                    });
+
+                    if (feeds.length > 0) {
+                        const feedsList = document.createElement('div');
+                        feedsList.id = 'feeds-list';
+
+                        for (let i = 0; i < feeds.length; i++) {
+                            feedsList.appendChild(createFeedCard(feeds[i], tab.title));
+                        }
+
+                        const feedsEl = document.getElementById('feeds');
+                        feedsEl.innerHTML = '';
+                        feedsEl.appendChild(feedsList);
+                        feedsEl.appendChild(createCopyAllContainer());
+
+                        // Copy to clipboard feed URL
+                        const copyButtons = document.getElementsByClassName('copyLink');
+
+                        for (let i = 0; i < copyButtons.length; i++) {
+                            copyButtons[i].addEventListener("click", function(e) {
+                                e.preventDefault();
+                                const button = this;
+                                const url = button.getAttribute('data-url');
+                                const btnText = button.querySelector('.btn-text');
+
+                                // Visual feedback
+                                button.classList.add('copied');
+                                const originalText = btnText.textContent;
+                                btnText.textContent = 'Copied!';
+
+                                setTimeout(() => {
+                                    button.classList.remove('copied');
+                                    btnText.textContent = originalText;
+                                }, 2000);
+
+                                copyToClipboard(url);
+                            });
+                        }
+
+                        // Copy to clipboard all feeds URLs
+                        const copyButtonAll = document.getElementById('copyAllLinks');
+
+                        copyButtonAll.addEventListener("click", function(e) {
+                            e.preventDefault();
+                            const button = this;
+                            const links = document.getElementById('feeds-list').querySelectorAll('.feed-title.link');
+                            const text = Array.from(links).map(a => a.getAttribute('href')).join('\n');
+
+                            // Visual feedback
+                            button.classList.add('copied');
+                            const btnText = button.querySelector('.btn-text');
+                            const originalText = btnText.textContent;
+                            btnText.textContent = 'Copied!';
+
+                            setTimeout(() => {
+                                button.classList.remove('copied');
+                                btnText.textContent = originalText;
+                            }, 2000);
+
+                            copyToClipboard(text);
+                        });
+
+                    } else {
+                        renderEmptyState();
+                    }
+                });
+            }
         });
     });
 });
@@ -134,6 +189,52 @@ function getFeedType(typeOrUrl) {
     if (type.includes('rdf')) return 'RDF';
 
     return '';
+}
+
+/**
+ * Render ignored state when site is in the ignore list
+ */
+function renderIgnoredState(hostname) {
+    const container = document.createElement('div');
+    container.className = 'ignored-state';
+
+    const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    icon.setAttribute('class', 'ignored-state-icon');
+    icon.setAttribute('viewBox', '0 0 24 24');
+    icon.setAttribute('fill', 'none');
+    icon.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    icon.innerHTML = '<circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/><path d="M5.636 5.636L18.364 18.364" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>';
+
+    const title = document.createElement('div');
+    title.className = 'ignored-state-title';
+    title.textContent = 'Site Ignored';
+
+    const text = document.createElement('div');
+    text.className = 'ignored-state-text';
+    text.textContent = 'RSS feeds are not searched for this site.';
+
+    const btn = document.createElement('button');
+    btn.className = 'unignore-btn';
+    btn.textContent = 'Enable for this site';
+    btn.addEventListener('click', function() {
+        chrome.storage.sync.get(['ignoredSites'], function(result) {
+            let sites = result.ignoredSites || [];
+            const idx = sites.indexOf(hostname);
+            if (idx !== -1) sites.splice(idx, 1);
+            chrome.storage.sync.set({ ignoredSites: sites }, function() {
+                location.reload();
+            });
+        });
+    });
+
+    container.appendChild(icon);
+    container.appendChild(title);
+    container.appendChild(text);
+    container.appendChild(btn);
+
+    const feedsEl = document.getElementById('feeds');
+    feedsEl.innerHTML = '';
+    feedsEl.appendChild(container);
 }
 
 /**

--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,10 @@
     "background": {
         "service_worker": "js/background.js"
     },
+    "options_ui": {
+        "page": "options.html",
+        "open_in_tab": true
+    },
     "commands": {
         "_execute_action": {
             "suggested_key": {

--- a/options.html
+++ b/options.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Get RSS Feed URLs – Options</title>
+    <link rel="stylesheet" href="css/options.css">
+</head>
+<body>
+
+<header>
+    <div class="header-content">
+        <svg class="rss-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M4 11C6.38695 11 8.67613 11.9482 10.364 13.636C12.0518 15.3239 13 17.6131 13 20" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M4 4C8.24346 4 12.3131 5.68571 15.3137 8.68629C18.3143 11.6869 20 15.7565 20 20" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            <circle cx="5" cy="19" r="1" fill="white"/>
+        </svg>
+        <h1>Get RSS Feed URLs — Options</h1>
+        <button id="theme-toggle" class="theme-toggle" title="Toggle theme" aria-label="Toggle dark mode">
+            <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="12" cy="12" r="4" stroke="currentColor" stroke-width="2"/>
+                <path d="M12 2V4M12 20V22M4 12H2M6.31412 6.31412L4.8999 4.8999M17.6859 6.31412L19.1001 4.8999M6.31412 17.69L4.8999 19.1042M17.6859 17.69L19.1001 19.1042M22 12H20" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+            </svg>
+            <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+        </button>
+    </div>
+</header>
+
+<main>
+
+    <!-- Badge Section -->
+    <section class="options-section">
+        <h2 class="section-title">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <rect x="3" y="3" width="18" height="18" rx="4" stroke="currentColor" stroke-width="2"/>
+                <path d="M9 12h6M12 9v6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+            </svg>
+            Badge
+        </h2>
+        <div class="option-row">
+            <div class="option-info">
+                <span class="option-label">Show feed count on icon</span>
+                <span class="option-desc">Display the number of RSS feeds found as a badge on the extension icon.</span>
+            </div>
+            <label class="toggle-switch" aria-label="Show feed count on icon">
+                <input type="checkbox" id="show-badge" checked>
+                <span class="toggle-slider"></span>
+            </label>
+        </div>
+    </section>
+
+    <!-- Cache Section -->
+    <section class="options-section">
+        <h2 class="section-title">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M19 7L18.1327 19.1425C18.0579 20.1891 17.187 21 16.1378 21H7.86224C6.81296 21 5.94208 20.1891 5.86732 19.1425L5 7M10 11V17M14 11V17M15 7V4C15 3.44772 14.5523 3 14 3H10C9.44772 3 9 3.44772 9 4V7M4 7H20" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            Cache
+        </h2>
+        <div class="option-row">
+            <div class="option-info">
+                <span class="option-label">Clear cached results</span>
+                <span class="option-desc">Remove all stored feed detection results. The cache will be rebuilt as you browse.</span>
+            </div>
+            <button id="clear-cache-btn" class="action-btn">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M19 7L18.1327 19.1425C18.0579 20.1891 17.187 21 16.1378 21H7.86224C6.81296 21 5.94208 20.1891 5.86732 19.1425L5 7M10 11V17M14 11V17M15 7V4C15 3.44772 14.5523 3 14 3H10C9.44772 3 9 3.44772 9 4V7M4 7H20" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                <span class="btn-text">Clear Cache</span>
+            </button>
+        </div>
+    </section>
+
+    <!-- Ignored Sites Section -->
+    <section class="options-section">
+        <h2 class="section-title">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/>
+                <path d="M5.636 5.636L18.364 18.364" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+            </svg>
+            Ignored Sites
+        </h2>
+        <div id="ignored-sites-container"></div>
+    </section>
+
+</main>
+
+<footer>
+    <span>By <a href="https://shevabam.fr" target="_blank">shevabam</a></span>
+    <span class="separator">•</span>
+    <a href="https://github.com/shevabam/get-rss-feed-url-extension" target="_blank">GitHub</a>
+    <span class="separator">•</span>
+    <a href="https://buymeacoffee.com/shevabam" target="_blank">🍕 Buy me a pizza</a>
+    <span class="separator">•</span>
+    <a id="review-link" href="#" target="_blank">Leave a review</a>
+</footer>
+
+<script src="js/options.js"></script>
+
+</body>
+</html>

--- a/popup.html
+++ b/popup.html
@@ -2,34 +2,42 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title></title>
+    <title>Get RSS Feed URLs</title>
     <link rel="stylesheet" href="css/popup.css">
 </head>
 <body class="rss-feed-url">
 
 <header>
     <div class="header-content">
-        <button id="ignore-site" class="ignore-toggle" title="Ignore this site" aria-label="Ignore this site">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/>
-                <path d="M5.636 5.636L18.364 18.364" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-        </button>
         <svg class="rss-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M4 11C6.38695 11 8.67613 11.9482 10.364 13.636C12.0518 15.3239 13 17.6131 13 20" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M4 4C8.24346 4 12.3131 5.68571 15.3137 8.68629C18.3143 11.6869 20 15.7565 20 20" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             <circle cx="5" cy="19" r="1" fill="white"/>
         </svg>
         <h1>Get RSS Feed URLs</h1>
-        <button id="theme-toggle" class="theme-toggle" title="Toggle theme" aria-label="Toggle dark mode">
-            <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <circle cx="12" cy="12" r="4" stroke="currentColor" stroke-width="2"/>
-                <path d="M12 2V4M12 20V22M4 12H2M6.31412 6.31412L4.8999 4.8999M17.6859 6.31412L19.1001 4.8999M6.31412 17.69L4.8999 19.1042M17.6859 17.69L19.1001 19.1042M22 12H20" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-            <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-        </button>
+        <div class="header-actions">
+            <button id="ignore-site" class="ignore-toggle" title="Ignore this site" aria-label="Ignore this site">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/>
+                    <path d="M5.636 5.636L18.364 18.364" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                </svg>
+            </button>
+            <button id="options-btn" class="settings-toggle" title="Options" aria-label="Open options">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="2"/>
+                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" stroke="currentColor" stroke-width="2"/>
+                </svg>
+            </button>
+            <button id="theme-toggle" class="theme-toggle" title="Toggle theme" aria-label="Toggle dark mode">
+                <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <circle cx="12" cy="12" r="4" stroke="currentColor" stroke-width="2"/>
+                    <path d="M12 2V4M12 20V22M4 12H2M6.31412 6.31412L4.8999 4.8999M17.6859 6.31412L19.1001 4.8999M6.31412 17.69L4.8999 19.1042M17.6859 17.69L19.1001 19.1042M22 12H20" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                </svg>
+                <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </button>
+        </div>
     </div>
 </header>
 

--- a/popup.html
+++ b/popup.html
@@ -9,6 +9,12 @@
 
 <header>
     <div class="header-content">
+        <button id="ignore-site" class="ignore-toggle" title="Ignore this site" aria-label="Ignore this site">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/>
+                <path d="M5.636 5.636L18.364 18.364" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+            </svg>
+        </button>
         <svg class="rss-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M4 11C6.38695 11 8.67613 11.9482 10.364 13.636C12.0518 15.3239 13 17.6131 13 20" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M4 4C8.24346 4 12.3131 5.68571 15.3137 8.68629C18.3143 11.6869 20 15.7565 20 20" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
Dedicated Options page, along with two new settings:

- Show badge toggle — lets users hide the RSS feed count badge on the extension icon
- Ignore a site — lets users add domains to an ignore list so the extension skips them entirely (no badge, no feed detection)
- Clear cache — button to manually flush the local feed count cache
