### PR TITLE
[Feat] Add Neocities RSS and allow crawling to be continue even after a match

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -198,6 +198,7 @@ const SERVICES_TO_CHECK = [
     'MediumTag',
     'Itchio',
     'MirrorXyz',
+    'Neocities',
 ];
 
 function checkIfUrlIsKnown(url) {
@@ -699,6 +700,30 @@ function getMirrorXyzRss(url) {
         datas.feeds.push({
             url: feed_url,
             title: subdomain
+        });
+    }
+
+    return datas;
+}
+
+
+
+/**
+ * Get RSS feed URL of a Neocities site (username.neocities.org)
+ */
+function getNeocitiesRss(url) {
+    let datas = { match: false, feeds: [] };
+
+    let regex = /^https?:\/\/([a-zA-Z0-9_-]+)\.neocities\.org(\/.*)?$/i;
+    let matches = url.match(regex);
+
+    if (matches) {
+        datas.match = true;
+        const username = matches[1];
+
+        datas.feeds.push({
+            url: 'https://neocities.org/site/' + username + '.rss',
+            title: username
         });
     }
 

--- a/js/functions.js
+++ b/js/functions.js
@@ -217,7 +217,7 @@ function checkIfUrlIsKnown(url) {
     }
 
     if (match === true) {
-        return check.feeds;
+        return { feeds: check.feeds, continueCrawl: check.continueCrawl || false };
     } else {
         return false;
     }
@@ -236,9 +236,11 @@ function getFeedsURLs(url, callback) {
 
     let getFeedUrl = checkIfUrlIsKnown(url);
 
-    if (false !== getFeedUrl && getFeedUrl.length > 0) {
-        callback(getFeedUrl);
+    if (false !== getFeedUrl && !getFeedUrl.continueCrawl) {
+        callback(getFeedUrl.feeds);
     } else {
+        let initialFeeds = (false !== getFeedUrl && getFeedUrl.continueCrawl) ? getFeedUrl.feeds : [];
+
         getHtmlSource(url, (response) =>  {
             if (response != '') {
                 let linkTags = extractLinkTags(response);
@@ -247,7 +249,7 @@ function getFeedsURLs(url, callback) {
                 document.getElementById('rss-feed-url_response').innerHTML = linkTags;
             }
 
-            searchFeed(url, callback);
+            searchFeed(url, callback, initialFeeds);
         });
     }
 }
@@ -255,7 +257,7 @@ function getFeedsURLs(url, callback) {
 /**
  * Search RSS Feed in source code
  */
-async function searchFeed(url, callback) {
+async function searchFeed(url, callback, initialFeeds = []) {
     let feeds_urls = [];
 
     if (document.getElementById('rss-feed-url_response').innerHTML != '') {
@@ -309,6 +311,8 @@ async function searchFeed(url, callback) {
             feeds_urls.push(test_feed);
         }
     }
+
+    feeds_urls = initialFeeds.concat(feeds_urls);
 
     callback(feeds_urls);
 
@@ -712,7 +716,7 @@ function getMirrorXyzRss(url) {
  * Get RSS feed URL of a Neocities site (username.neocities.org)
  */
 function getNeocitiesRss(url) {
-    let datas = { match: false, feeds: [] };
+    let datas = { match: false, feeds: [], continueCrawl: true };
 
     let regex = /^https?:\/\/([a-zA-Z0-9_-]+)\.neocities\.org(\/.*)?$/i;
     let matches = url.match(regex);


### PR DESCRIPTION
I have been exploring some pages on Neocities and this would be a help. I also added a feature to continue crawling even after matching because some pages have custom RSS.

Example: https://blaurascon.neocities.org/